### PR TITLE
Remove --registry from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ EXPOSE $DEVICE_PORT
 
 COPY --from=builder /go/src/github.com/edgexfoundry/device-snmp-go/cmd /
 
-ENTRYPOINT ["/device-snmp-go","--registry","--profile=docker","--confdir=/res"]
+ENTRYPOINT ["/device-snmp-go","--profile=docker","--confdir=/res"]

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-snmp-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go v0.0.0-20190524041108-4cdf0647f000
+	github.com/edgexfoundry/device-sdk-go v0.0.0-20190529004611-4ec3ceb83e9b
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.0
 	github.com/soniah/gosnmp v1.21.0
 )


### PR DESCRIPTION
Should not include --registry in the command line. It is consistent with the C Device Services.

Fix #5 