### PR TITLE
Update docker entrypoint params to run with consul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ EXPOSE $DEVICE_PORT
 
 COPY --from=builder /go/src/github.com/edgexfoundry/device-snmp-go/cmd /
 
-ENTRYPOINT ["/device-snmp-go","--profile=docker","--confdir=/res"]
+ENTRYPOINT ["/device-snmp-go","--profile=docker","--confdir=/res","--registry=consul://edgex-core-consul:8500"]


### PR DESCRIPTION
Add flag "--registry=consul://edgex-core-consul:8500" to the Dockerfile
ENTRYPOINT

fix: #22 

Signed-off-by: Felix Ting <felix@iotechsys.com>