### PR TITLE
Update SDK version to v1.1.1 and add missing attributions

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -95,3 +95,9 @@ https://github.com/golang/mock/blob/master/LICENSE
 
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE
+
+jessevdk/go-flags (BSD-3) https://github.com/jessevdk/go-flags
+https://github.com/jessevdk/go-flags/blob/master/LICENSE
+
+OneOfOne/xxhash (Apache 2.0) https://github.com/OneOfOne/xxhash
+https://github.com/OneOfOne/xxhash/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-snmp-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go v1.1.0
+	github.com/edgexfoundry/device-sdk-go v1.1.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.31
 	github.com/soniah/gosnmp v1.21.0
 )


### PR DESCRIPTION
update device-sdk-go to v1.1.1 and add missing attributions

Fix #36 