### PR TITLE
Update relevant files in device-snmp-go for Go 1.13.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE=golang:1.11-alpine
+ARG BASE=golang:1.13-alpine
 FROM ${BASE} AS builder
 
 ARG MAKE='make build'

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-ARG BASE=golang:1.11-alpine
+ARG BASE=golang:1.13-alpine
 FROM ${BASE}
 
 ARG ALPINE_PKG_BASE="make git"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,5 +16,5 @@
 
 edgeXBuildGoApp (
     project: 'device-snmp-go',
-    goVersion: '1.11'
+    goVersion: '1.13'
 )

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.31
 	github.com/soniah/gosnmp v1.21.0
 )
+
+go 1.13


### PR DESCRIPTION
Fix #43 
- After making the updates to the relevant files, I ensure that the Docker image get built and tagged.