### PR TITLE
refactor: Update to assign and uses new Port Assignments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=builder /device-snmp-go/cmd /
 COPY --from=builder /device-snmp-go/Attribution.txt /
 COPY --from=builder /device-snmp-go/LICENSE /
 
-EXPOSE 49993
+EXPOSE 59993
 EXPOSE 161
 
 ENTRYPOINT ["/device-snmp"]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Verify the deployment by navigating to your server address in your preferred bro
 Or you can use the curl command from your console if your on linux or OSX.  If you choose to use Postman just use the address less the curl command. 
 
 ```sh
-$ curl http://localhost:49993/api/v2/ping
+$ curl http://localhost:59993/api/v2/ping
 ```
 
 #### Reboot 
@@ -80,7 +80,7 @@ The current state of the Network Switch reboot
 ##### (SNMP OID)  `{ oid: "1.3.6.1.4.1.28866.2.37.24.5.1.0", community: "private"  }`
 
 ```sh
-$ curl http://localhost:49993/api/v2/trendnet01/Reboot
+$ curl http://localhost:59993/api/v2/trendnet01/Reboot
 ```
 
 #### UpTime 
@@ -88,42 +88,42 @@ The switch uptime since last reboot in TimeTicks
 ##### (SNMP OID) `{ oid: "1.3.6.1.4.1.28866.2.37.16.1.1.0", community: "private"  }`
 
 ```sh
-$ curl http://localhost:49993/api/v2/trendnet01/Uptime
+$ curl http://localhost:59993/api/v2/trendnet01/Uptime
 ```
 #### Firmware 
 The switch firmware version 
 ##### (SNMP OID) ` { oid: "1.3.6.1.4.1.28866.2.37.16.1.2.0", community: "private"  } `
 
 ```sh
-$ curl http://localhost:49993/api/v2/trendnet01/Firmware
+$ curl http://localhost:59993/api/v2/trendnet01/Firmware
 ```
 #### MACAddress
 The switch MAC Address 
 ##### (SNMP OID) `{ oid: "1.3.6.1.4.1.28866.2.37.16.2.1.0", community: "private"  } `
 
 ```sh
-$ curl http://localhost:49993/api/v2/trendnet01/MacAddress
+$ curl http://localhost:59993/api/v2/trendnet01/MacAddress
 ```
 #### IPV4Address
 The switch IPV4 Address 
 ##### (SNMP OID) `{ oid: "1.3.6.1.4.1.28866.2.37.16.1.2.0", community: "private"  } `
 
 ```sh
-$ curl http://localhost:49993/api/v2/trendnet01/IPV4Address
+$ curl http://localhost:59993/api/v2/trendnet01/IPV4Address
 ```
 #### IPV4SubnetMask
 The switch Subnet Mask 
 ##### (SNMP OID) `{ oid: "1.3.6.1.4.1.28866.2.37.16.3.3.0", community: "private"  } `
 
 ```sh
-$ curl http://localhost:49993/api/v2/trendnet01/IPV4SubnetMask
+$ curl http://localhost:59993/api/v2/trendnet01/IPV4SubnetMask
 ```
 #### IPV4GatewayAddress
 The switch IPV4 Gateway Address
 ##### (SNMP OID) `{ oid: "1.3.6.1.4.1.28866.2.37.16.3.4.0", community: "private"  } `
 
 ```sh
-$ curl http://localhost:49993/api/v2/trendnet01/IPV4GatewayAddress
+$ curl http://localhost:59993/api/v2/trendnet01/IPV4GatewayAddress
 ```
 #### PUT calls (REST)
 For the set commands we presently just have one.  I have included the SNMP MIB OID table entry(s) so you can see what OID's the device service is using. 
@@ -139,7 +139,7 @@ Restarts the switch
 | RebootControlState | 3 | Factory reset, restarts switch with no IP Address |
 
 ```sh
-$ curl -H 'Content-Type: application/json' -X PUT -d '{"RebootControlState":"1"}' http://localhost:49993/api/v2/Reboot
+$ curl -H 'Content-Type: application/json' -X PUT -d '{"RebootControlState":"1"}' http://localhost:59993/api/v2/Reboot
 ```
 
 ### Configuration

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -13,7 +13,7 @@ BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
 ServerBindAddr = ''  # blank value defaults to Service.Host value
-Port = 49993
+Port = 59993
 Protocol = 'http'
 StartupMsg = 'device snmp GO started'
 Timeout = 5000
@@ -32,12 +32,12 @@ Type = 'consul'
   [Clients.core-data]
   Protocol = 'http'
   Host = 'localhost'
-  Port = 48080
+  Port = 59880
 
   [Clients.core-metadata]
   Protocol = 'http'
   Host = 'localhost'
-  Port = 48081
+  Port = 59881
 
 [MessageQueue]
 Protocol = 'redis'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-snmp-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Ports assigned for Core/Supporting services are 408xx range
Device Modbus uses 49993

## Issue Number:  #97


## What is the new behavior?
Ports assigned for Core/Supporting services are 598xx range
Device SNMP default port number has changed to 59993

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Device SNMP default port number has changed to 59993

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
