### PR TITLE
fix: Remove retry items of SecretStore config and update secret path

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -59,13 +59,11 @@ PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<sour
 Type = 'vault'
 Host = 'localhost'
 Port = 8200
-Path = '/v1/secret/edgex/device-snmp/'
+Path = 'device-snmp/'
 Protocol = 'http'
 RootCaCertPath = ''
 ServerName = ''
 TokenFile = '/tmp/edgex/secrets/device-snmp/secrets-token.json'
-AdditionalRetryAttempts = 10
-RetryWaitPeriod = "1s"
   [SecretStore.Authentication]
   AuthType = 'X-Vault-Token'
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-snmp-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.70
+	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.71
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/soniah/gosnmp v1.21.0
 )


### PR DESCRIPTION
-  go-mod-bootstrap has implemented the addition of prefix /v1/secret/edgex/ for the Path property of SecretStore config section, so we just use the service specific secret path in Toml files

Fix: #104

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-snmp-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
old retry related items still in toml config and secret path is full path

## Issue Number: #104 


## What is the new behavior?
Remove retry related items of Secretstore config and update the secret path to be service specific path only


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
