### PR TITLE
FIX:edgex-launch.sh Error, disordered log output

### DIFF
--- a/bin/edgex-launch.sh
+++ b/bin/edgex-launch.sh
@@ -17,11 +17,11 @@ DIR=$PWD
 CMD=../cmd
 
 function cleanup {
-	pkill device-snmp-go
+	pkill device-snmp
 }
 
 cd $CMD
-exec -a device-snmp-go ./device-snmp-go &
+exec -a device-snmp ./device-snmp &
 cd $DIR
 
 

--- a/internal/driver/snmpdriver.go
+++ b/internal/driver/snmpdriver.go
@@ -63,8 +63,8 @@ func (s *SNMPDriver) HandleReadCommands(deviceName string, protocols map[string]
 
 	//s.lc.Debug(fmt.Sprintf("SimpleDriver.HandleReadCommands: protocols: %v operation: %v attributes: %v", protocols, reqs[0].RO.Operation, reqs[0].DeviceResource.Attributes))
 
-	s.lc.Debug("Port %s", Port)
-	s.lc.Debug("Address", Address)
+	s.lc.Debugf("Port %s", Port)
+	s.lc.Debugf("Address %s", Address)
 
 	var commands []DeviceCommand
 	for _, req := range reqs {


### PR DESCRIPTION
Service name definition in makefile:
`
MICROSERVICES=cmd/device-snmp
`
The edgex-launch.sh script should be consistent.

Original log:
`level=DEBUG ts=2022-03-15T08:55:33.909842445Z app=device-snmp source=snmpdriver.go:66 161= msg="Port %s"`
`level=DEBUG ts=2022-03-15T08:55:33.909857119Z app=device-snmp source=snmpdriver.go:67 192.168.11.253= msg=Address
`
Current log:
`level=DEBUG ts=2022-03-15T08:41:27.811814233Z app=device-snmp source=snmpdriver.go:66 msg="Port 161"`
`level=DEBUG ts=2022-03-15T08:41:27.811856064Z app=device-snmp source=snmpdriver.go:67 msg="Address 192.168.11.253"`