### PR TITLE
docs(snap): Move usage instructions to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ SNMP communication with the switch permits the device service to create events b
 > SNMP Traps are currently not implemented but will be completed at a future date. 
 > Network Switch Type abstraction
 
+### Packaging
+
+This component is packaged as docker image and snap.
+
+For docker, please refer to the [Dockerfile](Dockerfile) and [Docker Compose Builder] scripts.
+
+For the snap, refer to the [snap](snap) directory.
+
 
 ### Pre-Requisites
 
@@ -154,3 +162,4 @@ in the directory the application is executed from. See [cmd/res/configuration.to
 [ExCc]: <https://github.com/edgexfoundry/edgex-go/tree/master/internal/core/command/README.md>
 [ExCm]: <https://github.com/edgexfoundry/edgex-go/tree/master/internal/core/metadata/README.md>
 [ExWk]: <https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol>
+[Docker Compose Builder]: https://github.com/edgexfoundry/edgex-compose/tree/main/compose-builder

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,168 +1,38 @@
 # EdgeX SNMP Device Service Snap
+[![edgex-device-snmp](https://snapcraft.io/edgex-device-snmp/badge.svg)](https://snapcraft.io/edgex-device-snmp)
 
-[![snap store badge](https://raw.githubusercontent.com/snapcore/snap-store-badges/master/EN/%5BEN%5D-snap-store-black-uneditable.png)](https://snapcraft.io/edgex-device-snmp)
+This directory contains the snap packaging of the EdgeX SNMP device service.
 
-This folder contains snap packaging for the EdgeX SNMP Protocol Device Service Snap
+The snap is built automatically and published on the Snap Store as [edgex-device-snmp].
 
-The snap currently supports both `amd64` and `arm64` platforms
+For usage instructions, please refer to Device SNMP section in [Getting Started using Snaps][docs].
 
-## Installation
-
-### Installing snapd
-
-The snap can be installed on any system that supports snaps. You can see how to install snaps on your system [here](https://snapcraft.io/docs/installing-snapd/6735).
-
-However for full security confinement, the snap should be installed on an Ubuntu 18.04 LTS or later (Desktop or Server), or a system running Ubuntu Core 18 or later.
-
-### Installing EdgeX Device SNMP as a snap
-
-The snap is published in the snap store at https://snapcraft.io/edgex-device-snmp. You can see the current revisions available for your machine's architecture by running the command:
-
+## Build from source
+Execute the following command from the top-level directory of this repo:
 ```
-$ snap info edgex-device-snmp
+snapcraft
 ```
 
-The latest stable version of the snap can be installed using:
-
-```
-$ sudo snap install edgex-device-snmp
-```
-
-A specific release of the snap can be installed from a dedicated channel. For example, to install the 2.1 (Jakarta) release:
-
-```
-$ sudo snap install edgex-device-snmp --channel=2.1
+This will create a snap package file with `.snap` extension. It can be installed locally by setting the `--dangerous` flag:
+```bash
+sudo snap install --dangerous <snap-file>
 ```
 
-The latest development version of the snap can be installed using:
+The [snapcraft overview](https://snapcraft.io/docs/snapcraft-overview) provides additional details.
 
-```
-$ sudo snap install edgex-device-snmp --edge
-```
+### Obtain a Secret Store token
+The `edgex-secretstore-token` snap slot makes it possible to automatically receive a token from a locally installed platform snap.
 
-**Note** - the snap has only been tested on Ubuntu Core, Desktop, and Server.
+If the snap is built and installed locally, the interface will not auto-connect. You can check the status of the connections by running the `snap connections edgex-device-snmp` command.
 
-## Snap configuration
-
-Device services implement a service dependency check on startup which ensures that all of the runtime dependencies of a particular service are met before the service transitions to active state.
-
-Snapd doesn't support orchestration between services in different snaps. It is therefore possible on a reboot for a device service to come up faster than all of the required services running in the main edgexfoundry snap. If this happens, it's possible that the device service repeatedly fails startup, and if it exceeds the systemd default limits, then it might be left in a failed state. This situation might be more likely on constrained hardware (e.g. RPi).
-
-This snap therefore implements a basic retry loop with a maximum duration and sleep interval. If the dependent services are not available, the service sleeps for the defined interval (default: 1s) and then tries again up to a maximum duration (default: 60s). These values can be overridden with the following commands:
-
-To change the maximum duration, use the following command:
-
-```
-$ sudo snap set edgex-device-snmp startup-duration=60
+To manually connect and obtain a token:
+```bash
+sudo snap connect edgexfoundry:edgex-secretstore-token edgex-device-snmp:edgex-secretstore-token
 ```
 
-To change the interval between retries, use the following command:
+Please refer [here][secret-store-token] for further information.
 
-```
-$ sudo snap set edgex-device-snmp startup-interval=1
-```
 
-The service can then be started as follows. The "--enable" option ensures that as well as starting the service now, it will be automatically started on boot:
-
-```
-$ sudo snap start --enable edgex-device-snmp.device-snmp
-```
-
-### Using a content interface to set device configuration
-
-The `device-config` content interface allows another snap to seed this device
-snap with configuration files under the `$SNAP_DATA/config/device-snmp/res` directory.
-
-Note that the `device-config` content interface does NOT support seeding of the Secret Store Token because that file is expected at a different path.
-
-To use, create a new snap with a directory containing the configuration files. Your snapcraft.yaml file then needs to define a slot with read access to the directory you are sharing.
-
-```
-slots:
-  device-config:
-    interface: content  
-    content: device-config
-    read: 
-      - $SNAP/config
-```
-
-where `$SNAP/config` is configuration directory your snap is providing to the device snap.
-
-Then connect the plug in the device snap to the slot in your snap, which will replace the configuration in the device snap. Do this with:
-
-```
-$ sudo snap connect edgex-device-snmp:device-config your-snap:device-config
-```
-
-This needs to be done before the device service is started for the first time. Once you have set the configuration the device service can be started and it will then be configured using the settings you provided:
-
-```
-$ sudo snap start edgex-device-snmp.device-snmp
-```
-
-**Note** - content interfaces from snaps installed from the Snap Store that have the same publisher connect automatically. For more information on snap content interfaces please refer to the snapcraft.io [Content Interface](https://snapcraft.io/docs/content-interface) documentation.
-
-### Autostart
-
-By default, the edgex-device-snmp disables its service on install, as the expectation is that the default profile configuration files will be customized, and thus this behavior allows the profile `configuration.toml` files in $SNAP_DATA to be modified before the service is first started.
-
-This behavior can be overridden by setting the `autostart` configuration setting to "true". This is useful when configuration and/or device profiles are being provided via configuration or gadget snap content interface.
-
-**Note** - this option is typically set from a gadget snap.
-
-### Rich Configuration
-
-While it's possible on Ubuntu Core to provide additional profiles via gadget snap content interface, quite often only minor changes to existing profiles are required.
-
-These changes can be accomplished via support for EdgeX environment variable configuration overrides via the snap's configure hook. If the service has already been started, setting one of these overrides currently requires the service to be restarted via the command-line or snapd's REST API. If the overrides are provided via the snap configuration defaults capability of a gadget snap, the overrides will be picked up when the services are first started.
-
-The following syntax is used to specify service-specific configuration overrides:
-
-```
-env.<stanza>.<config option>
-```
-
-For instance, to setup an override of the service's Port use: 
-
-```
-$ sudo snap set edgex-device-snmp env.service.port=2112 
-```
-
-And restart the service: 
-
-```
-$ sudo snap restart edgex-device-snmp.device-snmp
-```
-
-**Note** - at this time changes to configuration values in the [Writable] section are not supported. For details on the mapping of configuration options to Config options, please refer to "Service Environment Configuration Overrides".
-
-## Service Environment Configuration Overrides
-
-**Note** - all of the configuration options below must be specified with the prefix: `env.`
-
-```
-[Service]
-service.health-check-interval   // Service.HealthCheckInterval
-service.host                    // Service.Host
-service.server-bind-addr        // Service.ServerBindAddr
-service.port                    // Service.Port
-service.max-result-count        // Service.MaxResultCount
-service.max-request-size        // Service.MaxRequestSize
-service.startup-msg             // Service.StartupMsg
-service.request-timeout         // Service.RequestTimeout
-
-[SecretStore]
-secret-store.secrets-file               // SecretStore.SecretsFile
-secret-store.disable-scrub-secrets-file // SecretStore.DisableScrubSecretsFile
-
-[Clients.core-data]
-clients.core-data.port          // Clients.core-data.Port
-
-[Clients.core-metadata]
-clients.core-metadata.port      // Clients.core-metadata.Port
-
-[Device]
-device.update-last-connected    // Device.UpdateLastConnected
-device.use-message-bus          // Device.UseMessageBus
-```
-
+[edgex-device-snmp]: https://snapcraft.io/edgex-device-snmp
+[docs]: https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#device-snmp
+[secret-store-token]: https://docs.edgexfoundry.org/2.2/getting-started/Ch-GettingStartedSnapUsers/#secret-store-token


### PR DESCRIPTION
Usage instructions are being moved to docs; see https://github.com/edgexfoundry/edgex-docs/pull/751.
The snap/README has been updated to include development docs only.

Depends on:
- https://github.com/edgexfoundry/edgex-docs/pull/751

Signed-off-by: Mengyi <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-snmp-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-snmp-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->