### PR TITLE
fix: Correctly set the versions for the service and sdk when building the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,24 @@ ARCH=$(shell uname -m)
 DOCKERS=docker_device_snmp_go
 .PHONY: $(DOCKERS)
 
+# This pulls the version of the SDK from the go.mod file. It works by looking for the line
+# with the SDK and printing just the version number that comes after it.
+SDKVERSION=$(shell sed -En 's|.*github.com/edgexfoundry/device-sdk-go/v2 (v[\.0-9a-zA-Z-]+).*|\1|p' go.mod)
+
+# this pulls the version from local VERSION file that is created by the Jenkins Pipeline.
 VERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
+
 GIT_SHA=$(shell git rev-parse HEAD)
 
-GOFLAGS=-ldflags "-X github.com/edgexfoundry/device-snmp-go.Version=$(VERSION)" -trimpath -mod=readonly
-CGOFLAGS=-ldflags "-linkmode=external -X github.com/edgexfoundry/device-snmp-go.Version=$(VERSION)" -trimpath -mod=readonly -buildmode=pie
+CGOFLAGS=-ldflags "-linkmode=external \
+				   -X github.com/edgexfoundry/device-sdk-go/v2/internal/common.SDKVersion=$(SDKVERSION) \
+                   -X github.com/edgexfoundry/device-snmp-go.Version=$(VERSION)" \
+                   -trimpath -mod=readonly -buildmode=pie
+
+build: $(MICROSERVICES)
 
 tidy:
 	go mod tidy
-
-build: $(MICROSERVICES)
 
 cmd/device-snmp:
 	$(GOCGO) build $(CGOFLAGS) -o $@ ./cmd

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,15 +9,15 @@ package main
 import (
 	"github.com/edgexfoundry/device-sdk-go/v2/pkg/startup"
 
+	"github.com/edgexfoundry/device-snmp-go"
 	"github.com/edgexfoundry/device-snmp-go/internal/driver"
 )
 
 const (
-	version     string = "1.0.0"
 	serviceName string = "device-snmp"
 )
 
 func main() {
 	sd := driver.SNMPDriver{}
-	startup.Bootstrap(serviceName, version, &sd)
+	startup.Bootstrap(serviceName, device_snmp_go.Version, &sd)
 }

--- a/version.go
+++ b/version.go
@@ -7,4 +7,4 @@
 package device_snmp_go
 
 // Global version for device-sdk-go
-const Version string = "0.7.0"
+var Version string = "to be replaced by makefile"


### PR DESCRIPTION

fixes #172

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-snmp-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-snmp-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
Start non-secure edgex stack
Create ./VERSION file locally with "2.2.0" as the contents
Build this branch
Run these service locally
Hit localhost:59993/api/v2/version
Verify it returns the following:
```
{
    "apiVersion": "v2",
    "version": "2.1.0",
    "serviceName": "device-snmp",
    "sdk_version": "v2.2.0"
}
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->