### PR TITLE
feat(snap): add config interface with unique identifier

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,9 +17,17 @@ epoch: 2
 slots:
   edgex-secretstore-token:
     interface: content
-    content: edgex-secretstore-token
     source:
       write: [$SNAP_DATA/device-snmp]
+plugs:
+  device-snmp-config:
+    interface: content
+    target: $SNAP_DATA/config/device-snmp
+
+  # deprecated
+  device-config:
+    interface: content
+    target: $SNAP_DATA/config/device-snmp
 
 apps:
   device-snmp:
@@ -37,11 +45,6 @@ apps:
     daemon: simple
     install-mode: disable
     plugs: [network, network-bind]
-
-plugs:
-  device-config:
-    interface: content
-    target: $SNAP_DATA/config/device-snmp
 
 parts:
   helper-go:


### PR DESCRIPTION
The device service snaps all have `device-config` as the config interface identifier. This is fine as long as we have one config provider per device service snaps. The identical names however prevent the user from having a single provider for multiple snaps. 

Setting up a content provider to seed multiple device snaps would result in the following error:
> connection not allowed by slot rule of interface "content"

It turns out that for manual connections (via snap connect or gadget's connections), the slot and plug name must be the same. From the docs:
> A slot and a plug can only be connected if they have the same interface name.
> https://snapcraft.io/docs/content-interface

This PR deprecates the old config interface in favor of one with a unique identifier.

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-snmp-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-snmp-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->